### PR TITLE
[ENG-6679] Support debug testing on Android

### DIFF
--- a/.detoxrc.json
+++ b/.detoxrc.json
@@ -28,7 +28,7 @@
     "simulator": {
       "type": "ios.simulator",
       "device": {
-        "type": "iPhone 11"
+        "type": "iPhone 14"
       }
     },
     "emulator": {

--- a/e2e/tests/homeScreen.e2e.js
+++ b/e2e/tests/homeScreen.e2e.js
@@ -1,11 +1,8 @@
-const { openAppForDebugBuild } = require('./utils/openAppForDebugBuild');
+const { openApp } = require('./utils/openApp');
 
 describe('Home screen', () => {
   beforeEach(async () => {
-    await device.launchApp({
-      newInstance: true,
-    });
-    await openAppForDebugBuild();
+    await openApp();
   });
 
   it('"Click me" button should be visible', async () => {

--- a/e2e/tests/utils/openApp.js
+++ b/e2e/tests/utils/openApp.js
@@ -1,11 +1,17 @@
 const appConfig = require('../../../app.json');
 
-module.exports.openAppForDebugBuild = async function openAppForDebugBuild() {
+module.exports.openApp = async function openApp() {
   const [platform, target] = process.env.DETOX_CONFIGURATION.split('.');
-  if (target !== 'debug') {
-    return;
+  if (target === 'debug') {
+    return await openAppForDebugBuild(platform);
+  } else {
+    return await device.launchApp({
+      newInstance: true,
+    });
   }
+}
 
+async function openAppForDebugBuild(platform) {
   const deepLinkUrl = process.env.EXPO_USE_UPDATES
     ? // Testing latest published EAS update for the test_debug channel
       getDeepLinkUrl(getLatestUpdateUrl())
@@ -13,13 +19,16 @@ module.exports.openAppForDebugBuild = async function openAppForDebugBuild() {
       getDeepLinkUrl(getDevLauncherPackagerUrl(platform));
 
   if (platform === 'ios') {
-    await device.launchApp();
-    sleep(1000);
+    await device.launchApp({
+      newInstance: true,
+    });
+    sleep(3000);
     await device.openURL({
       url: deepLinkUrl,
     });
   } else {
     await device.launchApp({
+      newInstance: true,
       url: deepLinkUrl,
     });
   }

--- a/e2e/tests/utils/openAppForDebugBuild.js
+++ b/e2e/tests/utils/openAppForDebugBuild.js
@@ -6,16 +6,26 @@ module.exports.openAppForDebugBuild = async function openAppForDebugBuild() {
     return;
   }
 
-  await sleep(1000);
-  await device.openURL({
-    url: process.env.EXPO_USE_UPDATES
-      // Testing latest published EAS update for the test_debug channel
-      ? getDeepLinkUrl(getLatestUpdateUrl())
-      // Local testing with packager
-      : getDeepLinkUrl(getDevLauncherPackagerUrl(platform)),
-  });
+  const deepLinkUrl = process.env.EXPO_USE_UPDATES
+    ? // Testing latest published EAS update for the test_debug channel
+      getDeepLinkUrl(getLatestUpdateUrl())
+    : // Local testing with packager
+      getDeepLinkUrl(getDevLauncherPackagerUrl(platform));
+
+  if (platform === 'ios') {
+    await device.launchApp();
+    sleep(1000);
+    await device.openURL({
+      url: deepLinkUrl,
+    });
+  } else {
+    await device.launchApp({
+      url: deepLinkUrl,
+    });
+  }
+
   await sleep(3000);
-}
+};
 
 const getDeepLinkUrl = (url) =>
   `eastestsexample://expo-development-client/?url=${encodeURIComponent(url)}`;
@@ -28,4 +38,4 @@ const getLatestUpdateUrl = () =>
 
 const getAppId = () => appConfig?.expo?.extra?.eas?.projectId ?? '';
 
-const sleep = t => new Promise(res => setTimeout(res, t));
+const sleep = (t) => new Promise((res) => setTimeout(res, t));

--- a/eas-hooks/eas-build-on-success.sh
+++ b/eas-hooks/eas-build-on-success.sh
@@ -20,6 +20,9 @@ if [[ "$EAS_BUILD_PLATFORM" == "android" ]]; then
   if [[ "$EAS_BUILD_PROFILE" == "test" ]]; then
     detox test --configuration android.release --headless
   fi
+  if [[ "$EAS_BUILD_PROFILE" == "test_debug" ]]; then
+    detox test --configuration android.debug --headless
+  fi
 
   # Kill emulator
   adb emu kill


### PR DESCRIPTION
Fixes #4 .

- Follow the suggestion by @david-alza to modify the Detox initialization correctly for Android vs. iOS
- Add the `test_debug` profile to the EAS success hook for Android